### PR TITLE
Feature/#22 ProspectiveOrganizersを翻訳しました

### DIFF
--- a/ProspectiveOrganizers/1_ProspectiveOrganizers.md
+++ b/ProspectiveOrganizers/1_ProspectiveOrganizers.md
@@ -1,16 +1,17 @@
 # Prospective Organizers
-
+# これからオーガナイザーになる人へ
 
 So you’ve decided to start your own PyLadies group – YAY!
-
+そんなわけで、あなたは自分自身のPyLadiesグループを立ち上げることにしました。いぇーい！
 
 We’re excited to have people like you join our growing community and want to help you get your group launched as quickly and painlessly as possible.
-
+私たちの成長中のコミュニティにあなたのような方が参加してくれてワクワクしています。あなたのグループができるだけ早く、簡単に立ち上がれるようにサポートしたいです。
 
 If our experience is any indication, your first major event will galvanize and inspire the Python community in your area and create momentum for subsequent events, so it’s crucial to start things off on the right foot!
-
+私たちの経験が何かの参考になれば、最初に開く大きなイベントはあなたの地域のPythonコミュニティに活気と刺激を与え、次のイベントのための推進力となるでしょう。そのため、最初に良いスタートを切れることはとても重要です。
 
 To help you get started, we’ve created this open-source kit for starting your own PyLadies group in your city. 
-
+あなたのスタートを手助けできるよう、私たちはあなたの都市でPyLadiesグループを立ち上げるためのオープンソース・キットを作りました。
 
 PyLadies is part social club, part stepping stone toward the Python open-source world.
+PyLadiesはソーシャルクラブのひとつであり、Pythonオープンソースワールドへの足がかりのひとつなのです。

--- a/ProspectiveOrganizers/1_ProspectiveOrganizers.md
+++ b/ProspectiveOrganizers/1_ProspectiveOrganizers.md
@@ -1,17 +1,17 @@
 # Prospective Organizers
 # これからオーガナイザーになる人へ
 
-So you’ve decided to start your own PyLadies group – YAY!
+So you’ve decided to start your own PyLadies group – YAY!   
 そんなわけで、あなたは自分自身のPyLadiesグループを立ち上げることにしました。いぇーい！
 
-We’re excited to have people like you join our growing community and want to help you get your group launched as quickly and painlessly as possible.
+We’re excited to have people like you join our growing community and want to help you get your group launched as quickly and painlessly as possible.   
 私たちの成長中のコミュニティにあなたのような方が参加してくれてワクワクしています。あなたのグループができるだけ早く、簡単に立ち上がれるようにサポートしたいです。
 
-If our experience is any indication, your first major event will galvanize and inspire the Python community in your area and create momentum for subsequent events, so it’s crucial to start things off on the right foot!
+If our experience is any indication, your first major event will galvanize and inspire the Python community in your area and create momentum for subsequent events, so it’s crucial to start things off on the right foot!   
 私たちの経験が何かの参考になれば、最初に開く大きなイベントはあなたの地域のPythonコミュニティに活気と刺激を与え、次のイベントのための推進力となるでしょう。そのため、最初に良いスタートを切れることはとても重要です。
 
-To help you get started, we’ve created this open-source kit for starting your own PyLadies group in your city. 
+To help you get started, we’ve created this open-source kit for starting your own PyLadies group in your city.   
 あなたのスタートを手助けできるよう、私たちはあなたの都市でPyLadiesグループを立ち上げるためのオープンソース・キットを作りました。
 
-PyLadies is part social club, part stepping stone toward the Python open-source world.
+PyLadies is part social club, part stepping stone toward the Python open-source world.   
 PyLadiesはソーシャルクラブのひとつであり、Pythonオープンソースワールドへの足がかりのひとつなのです。


### PR DESCRIPTION
レビューをお願いいたします。

1. markdownが崩れていたので英文の行末に改行用の半角スペース3文字を追加したら、差分表示がわかりにくくなってしまいました。すみません。（本当はプルリク分けた方がいい？）
2. タイトルは直訳で「将来のオーガナイザー」とすると少し違和感があったので、悩みつつ意訳しました。本家の目次を見たら「Prospective Organizers」「Current Organizers」「PyLadies Members」が並列になっているようなので、他の訳も見つつ表現を合わせた方がいいかもしれません。